### PR TITLE
Add sparse map handling

### DIFF
--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -135,8 +135,12 @@ class ArchiveEntry(object):
                                    timestamp_sec, timestamp_nsec)
 
     def _getpathname(self):
-        return (ffi.entry_pathname_w(self._entry_p) or
+        name = (ffi.entry_pathname_w(self._entry_p) or
                 ffi.entry_pathname(self._entry_p))
+        if isinstance(name, bytes):
+            return name.decode('utf8', 'surrogateescape')
+        else:
+            return name
 
     def _setpathname(self, value):
         if not isinstance(value, bytes):

--- a/libarchive/entry.py
+++ b/libarchive/entry.py
@@ -32,6 +32,11 @@ class ArchiveEntry(object):
         return self.pathname
 
     @property
+    def entry_p(self):
+        """ return entry pointer to be used by archive entry API functions """
+        return self._entry_p
+
+    @property
     def filetype(self):
         return ffi.entry_filetype(self._entry_p)
 

--- a/libarchive/ffi.py
+++ b/libarchive/ffi.py
@@ -141,6 +141,13 @@ ffi('entry_set_ctime', [c_archive_entry_p, c_int, c_long], None)
 
 ffi('entry_update_pathname_utf8', [c_archive_entry_p, c_char_p], None)
 
+ffi('entry_sparse_clear', [c_archive_entry_p], None)
+ffi('entry_sparse_count', [c_archive_entry_p], c_int)
+ffi('entry_sparse_reset', [c_archive_entry_p], c_int)
+ffi('entry_sparse_next', [c_archive_entry_p, POINTER(c_longlong),
+                          POINTER(c_longlong)], c_int)
+ffi('entry_sparse_add_entry', [c_archive_entry_p, c_longlong, c_longlong], None)
+
 ffi('entry_clear', [c_archive_entry_p], c_archive_entry_p)
 ffi('entry_free', [c_archive_entry_p], None)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from copy import copy
 from os import chdir, getcwd, stat, walk
 from os.path import abspath, dirname, join
 from stat import S_ISREG
+from string import printable
 import tarfile
 
 from libarchive import file_reader
@@ -135,3 +136,29 @@ def surrogate_decode(o):
     if isinstance(o, bytes):
         return o.decode('utf8', errors='surrogateescape')
     return o
+
+
+def generate_contents(size):
+    """ return contents of a certain size """
+    base_contents = printable
+    num = int(size / len(base_contents))
+
+    contents = base_contents * (num + 1)
+    return contents[:size]
+
+
+def create_sparse_file(fname, data_map, size):
+    """ Create a sparse file at fname with size.
+
+        data map is a list of (offset,length) of data blocks to write
+    """
+    with open(fname, 'w') as testf:
+        pos = testf.tell()
+        testf.truncate(size)
+
+        for (offset, length) in data_map:
+            if offset != pos:
+                testf.seek(offset)
+            data = generate_contents(length)
+            testf.write(data)
+        testf.flush()

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -10,9 +10,11 @@ from os.path import join
 
 import pytest
 
-from libarchive import memory_reader, memory_writer, file_reader
+from libarchive import memory_reader, memory_writer, file_reader, ffi
+from libarchive.write import new_archive_entry_from_path
 
-from . import data_dir, get_entries, get_tarinfos
+from . import (data_dir, get_entries, get_tarinfos, generate_contents,
+               create_sparse_file)
 
 
 locale.setlocale(locale.LC_ALL, '')
@@ -61,6 +63,90 @@ def test_entry_name_decoding(tar_file):
             # Use str find method to test it was converted from bytes to a
             # str/unicode
             entry.name.find('not there')
+
+
+# - 8k file, hole from 0->4096
+@pytest.mark.parametrize('size, write_map, sparse_map',
+                         [(8192, [(4096, 4096), ], [(4096, 4096), ]),
+                          (4096, [(0, 4096), ], []),
+                          (8192, [(0, 4096), ], [(0, 4096), (8192, 0)])
+                          ])
+def test_entry_sparse(tmpdir, size, write_map, sparse_map):
+    """ Test that we can write & read back a sparse file and the sparse map """
+    fname = tmpdir.join('sparse1').strpath
+
+    create_sparse_file(fname, write_map, size)
+
+    buf = bytes(bytearray(1000000))
+    with memory_writer(buf, 'pax') as archive:
+        archive.add_files(fname)
+
+    with memory_reader(buf) as archive:
+        for entry in archive:
+            assert entry.name == fname.lstrip('/')
+            assert entry.mode == stat(fname)[0]
+            assert entry.size == size
+
+            assert len(entry.sparse_map) == len(sparse_map)
+            assert entry.sparse_map == sparse_map
+
+
+@pytest.mark.parametrize('name', ['testtar.tar', ])
+def test_sparse_formats(name):
+    """ test for a good sparse map from all of the various sparse formats """
+    path = join(data_dir, name)
+    expected_map = [(4096, 4096), (12288, 4096), (20480, 4096), (28672, 4096),
+                    (36864, 4096), (45056, 4096), (53248, 4096),
+                    (61440, 4096), (69632, 4096), (77824, 4096), (86016, 0)]
+
+    with file_reader(path) as arch:
+        for entry in arch:
+            try:
+                if entry.name.startswith('gnu/sparse'):
+                    assert entry.size == 86016
+                    assert entry.sparse_map == expected_map
+            except UnicodeDecodeError:
+                # py27 fails on some unicode
+                pass
+
+
+@pytest.mark.parametrize('sparse_map',
+                         [[(0, 4096), (8192, 0)],
+                          [(0, 0), (4096, 4096)]
+                          ])
+def test_entry_sparse_manual(tmpdir, sparse_map):
+    """ Can we archive a partial non-sparse file as sparse """
+    fname = tmpdir.join('sparse1').strpath
+
+    size = 8192
+    with open(fname, 'w') as testf:
+        testf.write(generate_contents(8192))
+
+    buf = bytes(bytearray(1000000))
+    with memory_writer(buf, 'pax') as archive:
+        with new_archive_entry_from_path(fname) as entry:
+            assert len(entry.sparse_map) == 0
+            entry.sparse_map.extend(sparse_map)
+
+            # not using archive.add_entries, that assumes the entry comes from
+            # another archive and tries to use entry.get_blocks()
+            write_p = archive._pointer
+
+            ffi.write_header(write_p, entry.entry_p)
+
+            with open(fname, 'rb') as testf:
+                entry_data = testf.read()
+                ffi.write_data(write_p, entry_data, len(entry_data))
+            ffi.write_finish_entry(write_p)
+
+    with memory_reader(buf) as archive:
+        for entry in archive:
+            assert entry.name == fname.lstrip('/')
+            assert entry.mode == stat(fname)[0]
+            assert entry.size == size
+
+            assert len(entry.sparse_map) == len(sparse_map)
+            assert entry.sparse_map == sparse_map
 
 
 def test_check_ArchiveEntry_against_TarInfo():

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -8,7 +8,9 @@ import locale
 from os import environ, stat
 from os.path import join
 
-from libarchive import memory_reader, memory_writer
+import pytest
+
+from libarchive import memory_reader, memory_writer, file_reader
 
 from . import data_dir, get_entries, get_tarinfos
 
@@ -47,6 +49,18 @@ def test_entry_properties():
             assert b'rw' in entry.strmode
             assert entry.pathname == entry.path
             assert entry.pathname == entry.name
+
+
+@pytest.mark.parametrize('tar_file', ['testtar.tar', ])
+def test_entry_name_decoding(tar_file):
+    """ Test that the entry names are decoded to utf8 correctly """
+    path = join(data_dir, tar_file)
+
+    with file_reader(path) as arch:
+        for entry in arch:
+            # Use str find method to test it was converted from bytes to a
+            # str/unicode
+            entry.name.find('not there')
 
 
 def test_check_ArchiveEntry_against_TarInfo():


### PR DESCRIPTION
We need a couple of interface fixups to start, as they enable testing patterns in the final sparse commit. The bulk of this change is the ability to read and write sparse maps from a libarchive ArchiveEntry.